### PR TITLE
Add an extension icon counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ It will then submit the form in the background, and refresh the page, which will
 2. Drag and drop the "dist" folder to chrome://extensions.
 3. Visit the [survey page](https://action.donaldjtrump.com/mainstream-media-accountability-survey/).
 4. Profit :-)
+
+## Contributing
+
+Fork, Pull forked repo, create new branch. (blah, blah)
+
+Install npm.
+Change to project directory.
+Install Grunt in project: `npm install grunt --save-dev`
+Install dev dependencies: `npm install --save-dev`
+Make modifications in `src/`.
+Build changes: `grunt`.
+
+Test, git push, and open PR :) (thanks for your contribution!)

--- a/dist/js/background-bundle.js
+++ b/dist/js/background-bundle.js
@@ -1657,6 +1657,27 @@ function submitForm(tabId, payload) {
             chrome.tabs.reload(tabId, reloadProperties);
         });
     });
+
+    // Record Submission Counter
+    chrome.storage.local.get("fucksGiven", function (data) {
+        if (data.hasOwnProperty("fucksGiven")) {
+            data.fucksGiven += 1;
+        } else if (chrome.runtime.lastError) {
+            console.log("Encountered error: " + chrome.extension.lastError.toString());
+        } else {
+            data = { "fucksGiven": 1 };
+        }
+
+        chrome.storage.local.set(data, function (r) {
+            if (!chrome.runtime.lastError) {
+                console.log("Successfully recorded form submission #" + data.fucksGiven.toString());
+            } else {
+                console.log('An error occurred: ' + chrome.extension.lastError.message);
+            }
+        });
+        chrome.browserAction.setBadgeText({ text: data.fucksGiven.toString() });
+        // TODO: Handle when integer becomes larger than 4 characters. This is truncated in the badge text.
+    });
 };
 
 chrome.runtime.onMessage.addListener(function (message, sender, callback) {

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -12,6 +12,7 @@
         "webRequestBlocking",
         "https://*.donaldjtrump.com/*"
     ],
+    "browser_action": {},
     "incognito": "split",
     "content_security_policy": "script-src 'self' https://action.donaldjtrump.com; object-src 'self' https://action.donaldjtrump.com",
     "background": {

--- a/src/app/Background.js
+++ b/src/app/Background.js
@@ -19,6 +19,27 @@ function submitForm(tabId, payload){
             chrome.tabs.reload(tabId, reloadProperties);
         });
     });
+
+    // Record Submission Counter
+    chrome.storage.local.get("fucksGiven", function(data) {
+        if (data.hasOwnProperty("fucksGiven")) {
+            data.fucksGiven += 1;
+        } else if (chrome.runtime.lastError) {
+            console.log("Encountered error: " + chrome.extension.lastError.toString());
+        } else {
+            data = {"fucksGiven": 1};
+        }
+
+        chrome.storage.local.set(data, function(r) {
+          if (!chrome.runtime.lastError) {
+            console.log("Successfully recorded form submission #" + data.fucksGiven.toString());
+          } else {
+            console.log('An error occurred: ' + chrome.extension.lastError.message);
+          }
+        });
+        chrome.browserAction.setBadgeText({text: data.fucksGiven.toString()});
+        // TODO: Handle when integer becomes larger than 4 characters. This is truncated in the badge text.
+    });
 };
 
 chrome.runtime.onMessage.addListener((message, sender, callback) => {


### PR DESCRIPTION
I thought that this plugin needed a nice counter to be able to see how many times we've been able to spam this survey :)

Counter badge gets truncated after 4 characters, but I'll just add a FIXME note for now.